### PR TITLE
Update 0.2.0

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -38,6 +38,7 @@ end)
 
 -- Washed Menu
 function OpenWashedMenu(zone)
+	print(zone)
 	local elements = {
 		{label = _U('wash_money'), 	value = 'wash_money'},
 		--{label = _U('no'),			value = 'no'}
@@ -61,7 +62,7 @@ function OpenWashedMenu(zone)
 						ESX.ShowNotification(_U('invalid_amount'))
 					else
 						menu.close()
-						TriggerServerEvent('esx_moneywash:washMoney', amount)
+						TriggerServerEvent('esx_moneywash:washMoney', amount, zone)
 					end
 				end, function(data, menu)
 					menu.close()
@@ -107,8 +108,8 @@ Citizen.CreateThread(function()
 		
 			for i = 1, #zoneID.Pos, 1 do
 			
-				if isAuthorized and (Config.Type ~= -1 and GetDistanceBetweenCoords(coords, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, true) < Config.DrawDistance) then
-					DrawMarker(Config.Type, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, Config.Size.x, Config.Size.y, Config.Size.z, Config.Color.r, Config.Color.g, Config.Color.b, 100, false, true, 2, false, false, false, false)
+				if isAuthorized and (zoneID.Type ~= -1 and GetDistanceBetweenCoords(coords, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, true) < Config.DrawDistance) then
+					DrawMarker(zoneID.Type, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, zoneID.Size.x, zoneID.Size.y, zoneID.Size.z, zoneID.Color.r, zoneID.Color.g, zoneID.Color.b, 100, false, true, 2, false, false, false, false)
 				end
 				
 			end
@@ -133,7 +134,7 @@ Citizen.CreateThread(function()
 			local isAuthorized 	= Authorized(zoneID)
 			
 			for i = 1, #zoneID.Pos, 1 do
-				if isAuthorized and (GetDistanceBetweenCoords(coords, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, true) < Config.Size.x) then
+				if isAuthorized and (GetDistanceBetweenCoords(coords, zoneID.Pos[i].x, zoneID.Pos[i].y, zoneID.Pos[i].z, true) < zoneID.Size.x) then
 					isInMarker = true
 					currentZone = k
 				end

--- a/config.lua
+++ b/config.lua
@@ -1,19 +1,12 @@
 Config 					= {}
 
 Config.Locale 			= 'en'
-Config.DrawDistance 	= 100
-Config.Size 			= {x = 1.5, y = 1.5, z = 1.5}
-Config.Color 			= {r = 255, g = 120, b = 0}
-Config.Type 			= 1
+Config.DrawDistance 	= 10
 
-Config.taxRate = 0.65  --65% of the dirty you will get back in clean
 
-Config.enableTimer = true -- Enable ONLY IF you want a timer on the money washing. Keep in mind the Player does not have to stay at the wash for it to actually wash the money.
 local second = 1000
 local minute = 60 * second
 local hour = 60 * minute
-
-Config.timer = 5 * second -- Time it takes to wash money. The * amount will determine if its hours, second, or minutes.
 
 --[[ 
 	Below are the zones for laundering. You can set multiple zones just follow the format below. 
@@ -33,32 +26,49 @@ Config.timer = 5 * second -- Time it takes to wash money. The * amount will dete
 			--'any', -- SET THE 'any' TAG TO ALLOW ALL JOBS INCLUDING POLICE TO USE THE LOCATION
 			--'miner',
 			--'cardealer'
-		}
+		},
+		TaxRate = 0.50, -- set taxrate per spot. Default is 0.5 or 50% of the dirty you will get back in clean
+		enableTimer = false, -- Enable ONLY IF you want a timer on the money washing. Keep in mind the Player does not have to stay at the wash for it to actually wash the money.
+		timer = 5 * second -- Actual Timer for the spot. The * amount will determine if its hours, second, or minutes. which are found above. DEFAULT: 5 * second
 	},
 	
 ]]
 
 Config.Zones = {
 	
-	{	
+	['LaundryMat'] = {	
 		Pos = { 
-			{x = 1122.5 , y = -3194.98 , z = -41.60},
+			{x = 1122.5 , y = -3194.98 , z = -40.60},
 		},
 		
 		Jobs = {
 			--'any', -- set to 'any' to allow the location for any player regardless of job
-			'cardealer'
-		}
+			'miner'
+		},
+		TaxRate = 0.50, -- set taxrate per spot. Default is 0.5 or 50% of the dirty you will get back in clean
+		enableTimer = false, -- Enable ONLY IF you want a timer on the money washing. Keep in mind the Player does not have to stay at the wash for it to actually wash the money.
+		timer = 5 * second, -- Actual Timer for the spot. The * amount will determine if its hours, second, or minutes. which are found above. DEFAULT: 5 * second
+		Size = {x = 1.5, y = 1.5, z = 1.5},
+		Color = {r = 120, g = 120, b = 0},
+		Type = 27,
+	
 	},
 	
-	--[[{
+	['Warehouse'] = {
 		Pos = {
 			{x = 1090.84 , y = -2233.43 , z = 31.5}
 		},
 		
 		Jobs = {
-			--'miner',
-			'cardealer'
-		}
-	},]]
+			--'any', -- set to 'any' to allow the location for any player regardless of job
+			'fueler'
+		},
+		TaxRate = 0.85, -- set taxrate per spot. Default is 0.85 or 85% of the dirty you will get back in clean
+		enableTimer = true, -- Enable ONLY IF you want a timer on the money washing. Keep in mind the Player does not have to stay at the wash for it to actually wash the money.
+		timer = 5 * second, -- Actual Timer for the spot. The * amount will determine if its hours, second, or minutes. which are found above. DEFAULT: 5 * second
+		Size = {x = 1.5, y = 1.5, z = 1.5},
+		Color = {r = 255, g = 120, b = 0},
+		Type = 1,
+	
+	}
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -16,15 +16,28 @@ function secondsToClock(seconds)
 end
 
 RegisterServerEvent('esx_moneywash:washMoney')
-AddEventHandler('esx_moneywash:washMoney', function(amount)
+AddEventHandler('esx_moneywash:washMoney', function(amount, zone)
 	local xPlayer = ESX.GetPlayerFromId(source)
-	local tax = Config.taxRate
+	local tax
+	local timer
+	local enableTimer = false
+	print(zone)
+	for k, spot in pairs (Config.Zones) do
+		if zone == k then
+			tax = spot.TaxRate
+			enableTimer = spot.enableTimer
+			timer = spot.timer
+		end
+	end
+	print(tax)
 	amount = ESX.Math.Round(tonumber(amount))
 	washedCash = amount * tax
 	washedTotal = ESX.Math.Round(tonumber(washedCash))
+
+	print(tax.. ' ' .. timer)
 	
-	if Config.enableTimer == true then
-		local timer = Config.timer
+	if enableTimer == true then
+		--local timer = Config.timer
 		local timeClock = ESX.Math.Round(timer / 1000)
 	
 		if amount > 0 and xPlayer.getAccount('black_money').money >= amount then

--- a/version.json
+++ b/version.json
@@ -1,7 +1,11 @@
 {
-		"version":"0.1.2",
+		"version":"0.2.0",
 		"patchnotes" : [
-			"- Removed __resource.lua to update to newer manifest",
-			"- Added fxmanifest.lua to bring resource up to newest manifest"
+			"- Add per spot tax rates. IE each spot has a different tax rate. Follow config file to implement",
+			"- Add per spot timers. IE each spot can either have a timer or not have a timer",
+			"- Add per spot timer lengths. IE each spot can have a different time to actually wash the money.",
+			"- Add size, color, and type on a per spot basis. IE each wash zone can have a different color size or marker type",
+			"- Reduce default Draw Amount to 10. Should improve performance a little bit instead of drawing the marker when so far away. Can be changed if you want though."
+			
 		]
 }

--- a/version.lua
+++ b/version.lua
@@ -1,5 +1,5 @@
 --[[ Version Checker ]]--
-local VERSION = "0.1.2"
+local VERSION = "0.2.0"
 
 AddEventHandler("onResourceStart", function(resource)
     if resource == GetCurrentResourceName() then


### PR DESCRIPTION
Update 0.2.0:

- Add per spot tax rates. IE each spot has a different tax rate. Follow config file to implement

- Add per spot timers. IE each spot can either have a timer or not have a timer

- Add per spot timer lengths. IE each spot can have a different time to actually wash the money.

- Add size, color, and type on a per spot basis. IE each wash zone can have a different color size or marker type

- Reduce default Draw Amount to 10. Should improve performance a little bit instead of drawing the marker when so far away. Can be changed if you want though.